### PR TITLE
Fix: Replace method hiding with virtual override to prevent NullReferenceException

### DIFF
--- a/src/DotNetOrb.Core/ETF/ProfileBase.cs
+++ b/src/DotNetOrb.Core/ETF/ProfileBase.cs
@@ -25,7 +25,7 @@ namespace DotNetOrb.Core.ETF
         protected string corbalocStr = null;
         protected ILogger logger;
 
-        public void Configure(IConfiguration configuration)
+        public virtual void Configure(IConfiguration configuration)
         {
             if (configuration == null)
             {

--- a/src/DotNetOrb.Core/IIOP/IIOPConnectionFactory.cs
+++ b/src/DotNetOrb.Core/IIOP/IIOPConnectionFactory.cs
@@ -39,7 +39,7 @@ namespace DotNetOrb.Core.IIOP
         /// </summary>
         public IProfile DemarshalProfile(ref TaggedProfile taggedProfile, out TaggedComponent[] components)
         {
-            ProfileBase profile = new IIOPProfile();
+            IIOPProfile profile = new IIOPProfile();
 
             profile.Configure(configuration);
 

--- a/src/DotNetOrb.Core/IIOP/IIOPProfile.cs
+++ b/src/DotNetOrb.Core/IIOP/IIOPProfile.cs
@@ -79,7 +79,7 @@ namespace DotNetOrb.Core.IIOP
         }
 
 
-        public new void Configure(IConfiguration config)
+        public override void Configure(IConfiguration config)
         {
             base.Configure(config);
 

--- a/src/DotNetOrb.Core/MIOP/MIOPProfile.cs
+++ b/src/DotNetOrb.Core/MIOP/MIOPProfile.cs
@@ -81,7 +81,7 @@ namespace DotNetOrb.Core.MIOP
         }
 
 
-        public new void Configure(IConfiguration config)
+        public override void Configure(IConfiguration config)
         {
             base.Configure(config);
 


### PR DESCRIPTION
### Problem
System.NullReferenceException: "Object reference not set to an instance of an object." in `IIOPProfile::GetSslPortIfSupported` at if `(logger.IsDebugEnabled)` because `logger` of class `IIOPProfile` is null.

### Root Cause
This code calls `Configure` method, on baseclass `ProfileBase`.
```
IIOPConnectionFactory::DemarshalProfile(...) {
ProfileBase profile = new IIOPProfile();
profile.Configure(configuration);
```
Method `Configure` is not virtual! So `Configure` method of class `IIOPProfile` is never called and `logger` is null.

### Changes
Method `Configure` in baseclass `ProfileBase` is now virtual and overridden in class `IIOPProfile`.
Member `profile` in function `IIOPConnectionFactory::DemarshalProfile(...)` has concrete type. (Not neccesary anymore but for better understanding).

### Testing
Verified that exception is not raised anymore.