### PR TITLE
Fix: Make client certificate optional when EstablishTrustInClient is not required

### DIFF
--- a/src/DotNetOrb.Core/IIOP/ClientIIOPConnection.cs
+++ b/src/DotNetOrb.Core/IIOP/ClientIIOPConnection.cs
@@ -31,7 +31,6 @@ namespace DotNetOrb.Core.IIOP
         private int idleTimeout;
         protected int noOfRetries = 5;
         protected int retryInterval = 0;
-        protected X509Certificate2 tlsCertificate = null;
 
         private IIOPAddress? address;
         private IPEndPoint? endpoint;
@@ -85,13 +84,23 @@ namespace DotNetOrb.Core.IIOP
                 isSSL = SSLPort != -1;
             }
 
+            ClientTlsSettings? clientTlsSettings = null;
             if (isSSL)
             {
-                //TODO Retrieve certificate from X509Store ??
-                var certPath = config.GetValue("DotNetOrb.IIOP.SSL.Certificate");
-                var pwd = config.GetValue("DotNetOrb.IIOP.SSL.CertificatePassword");
-                tlsCertificate = new X509Certificate2(certPath, pwd);
-                //targetHost = tlsCertificate.GetNameInfo(X509NameType.DnsName, false);
+                if ((clientSupported & EstablishTrustInClient.Value) != 0)
+                {
+                    //TODO Retrieve certificate from X509Store ??
+                    var certPath = config.GetValue("DotNetOrb.IIOP.SSL.Certificate");
+                    var certPwd = config.GetValue("DotNetOrb.IIOP.SSL.CertificatePassword");
+                    var tlsCertificate = new X509Certificate2(certPath, certPwd);
+
+                    var targetHost = address?.HostName; //ToDo: tlsCertificate.GetNameInfo(X509NameType.DnsName, false)
+                    clientTlsSettings = new ClientTlsSettings(targetHost, new List<X509Certificate> { tlsCertificate });
+                }
+                else
+                {
+                    clientTlsSettings = new ClientTlsSettings(address?.HostName);
+                }
             }
 
 
@@ -105,23 +114,14 @@ namespace DotNetOrb.Core.IIOP
                    .Handler(new ActionChannelInitializer<ISocketChannel>(channel =>
                    {
                        IChannelPipeline pipeline = channel.Pipeline;
-                       ClientTlsSettings settings;
-                       if ((clientSupported & EstablishTrustInClient.Value) != 0 && tlsCertificate != null)
-                       {
-                           settings = new ClientTlsSettings(address?.HostName, new List<X509Certificate>() { tlsCertificate });
-                       }
-                       else
-                       {
-                           settings = new ClientTlsSettings(address?.HostName);
-                       }
-                       if (tlsCertificate != null)
+                       if (clientTlsSettings != null)
                        {
                            var tls = channel.Pipeline.Get<TlsHandler>();
                            if (tls != null)
                            {
                                channel.Pipeline.Remove(tls);
                            }
-                           channel.Pipeline.AddFirst(new TlsHandler(stream => new SslStream(stream, true, (sender, certificate, chain, errors) => true), settings));
+                           channel.Pipeline.AddFirst(new TlsHandler(stream => new SslStream(stream, true, (sender, certificate, chain, errors) => true), clientTlsSettings));
                        }
                        if (idleTimeout > 0)
                        {


### PR DESCRIPTION
### Problem
The library always required a client certificate for SSL connections, even in cases where EstablishTrustInClient was not enabled. This unnecessarily restricted valid usecase, where a client connection without a certificate, is perfectly acceptable.
This option lowers the barrier to entry, as client development typically never requires a certificate.
For example **ssliop** in `ORBInitRef.NameService` with `corbaloc:ssliop:1.2@example.org/NameService`

### Root Cause
A missing client certificate always resulted a connction without `TlsHandler` in `channel.Pipeline`.

### Changes
Client certificate is now only required when EstablishTrustInClient is enabled.
If TrustInClient is disabled, a client connection without a certificate is accepted.
Existing behavior for `EstablishTrustInClient` is fully preserved and unchanged.
No changes to the public API.

### Why this is safe
This change does not weaken security for configurations that require mutual authentication. The certificate check is still strictly enforced when `EstablishTrustInClient`. The change only removes an unnecessary restriction for configurations that explicitly do not require it, which is consistent with standard SSL/TLS behavior (e.g. one-way TLS).

### Testing
Verified that connections with `EstablishTrustInClient = true` still require and validate a client certificate
Verified that connections with `EstablishTrustInClient = false` succeed without a client certificate