### PR TITLE
Fix: Use OrdinalIgnoreCase for codeset name comparison

### DIFF
--- a/src/DotNetOrb.Core/CDR/CodeSet.cs
+++ b/src/DotNetOrb.Core/CDR/CodeSet.cs
@@ -140,11 +140,10 @@ namespace DotNetOrb.Core.CDR
         /// </summary>
         public static CodeSet GetCodeSet(string name)
         {
-            string ucName = name.ToUpper();
             for (int i = 0; i < KnownEncodings.Length; i++)
             {
                 CodeSet codeset = KnownEncodings[i];
-                if (codeset.Name.Equals(ucName)) return codeset;
+                if (codeset.Name.Equals(name, StringComparison.OrdinalIgnoreCase)) return codeset;
             }
 
             try


### PR DESCRIPTION
### Problem
When resolving a codeset by name, the comparison was performed case-sensitively (ToUpper()). This caused lookups to fail when the codeset name was provided in a different casing than expected, even though the name was otherwise correct.

### Root Cause
Because in ORB.ConfigureCodeset() there is a exception-handler, which is supressing all CodeSetIncompatible-exception. So it went unnoticed.
The Equals comparison used the default case-sensitive string comparison. Codeset names are identifiers and should be treated as case-insensitive by convention.

### Changes
Replaced the default Equals comparison with StringComparison.OrdinalIgnoreCase
No changes to data structures, public API, or codeset definitions

### Testing
Verified that codeset names are resolved correctly regardless of casing (e.g. "UTF-8", "utf-8", "Utf-8" all resolve to the same codeset)
