### PR TITLE
fix: Resolve systematic stream mismatch in constructor causing incorrect field initialization

### DIFF
--- a/src/DotNetOrb.Core/GIOP/GIOPCancelRequestMessage.cs
+++ b/src/DotNetOrb.Core/GIOP/GIOPCancelRequestMessage.cs
@@ -15,7 +15,7 @@ namespace DotNetOrb.Core.GIOP
             this.content.AddComponent(content);
             this.content.SetWriterIndex(this.content.WriterIndex + content.ReadableBytes);
             Header = new GIOPHeader(this.content);
-            CDRInputStream input = new CDRInputStream(ORB, content, Header.GIOPVersion.Minor, Header.IsLittleEndian);
+            CDRInputStream input = new CDRInputStream(ORB, this.content, Header.GIOPVersion.Minor, Header.IsLittleEndian);
             RequestId = input.ReadULong();
         }
 

--- a/src/DotNetOrb.Core/GIOP/GIOPLocateRequestMessage.cs
+++ b/src/DotNetOrb.Core/GIOP/GIOPLocateRequestMessage.cs
@@ -21,7 +21,7 @@ namespace DotNetOrb.Core.GIOP
             {
                 throw new CORBA.Marshal("Not a Locate request!");
             }
-            CDRInputStream input = new CDRInputStream(ORB, content, Header.GIOPVersion.Minor, Header.IsLittleEndian);
+            CDRInputStream input = new CDRInputStream(ORB, this.content, Header.GIOPVersion.Minor, Header.IsLittleEndian);
             switch (Header.GIOPVersion.Minor)
             {
                 case 0:


### PR DESCRIPTION
### Summary
This PR fixes a systematic bug in the constructor where fields were being read from an incorrect stream at one location, while another location correctly read from the right stream.

### Root Cause
In the constructor, there were two read operations — one targeting the correct stream and one accidentally targeting the wrong stream. `this.content` and `content`

### Impact
* requestId was populated with a wrong/stale value
* objectKey was populated from the wrong stream source
Any downstream logic depending on these fields received corrupted data

### Fix
Corrected the stream reference at the affected constructor location so that all fields are consistently read from the right stream.

Testing
Verified requestId and objectKey are correctly set after construction