### PR TITLE
fix: Call Configure() after cloning IIOPProfile to prevent NullReferenceException

### DIFF
--- a/src/DotNetOrb.Core/IIOP/IIOPProfile.cs
+++ b/src/DotNetOrb.Core/IIOP/IIOPProfile.cs
@@ -410,6 +410,8 @@ namespace DotNetOrb.Core.IIOP
         public override object Clone()
         {
             IIOPProfile result = new IIOPProfile();
+            result.Configure(configuration);
+
             result.primaryAddress = new IIOPAddress(primaryAddress.HostName, primaryAddress.Port);
             result.isSSLSet = isSSLSet;
             result.ssl = ssl;


### PR DESCRIPTION
### Summary
This PR fixes a bug where cloning an IIOPProfile instance omitted the required call to Configure(), leaving internal state uninitialized and causing a NullReferenceException on subsequent access.

### Root Cause
When IIOPProfile was cloned, the constructor did not invoke Configure(). As a result, fields that depend on configuration — such as `configuration.ORB.GiopMinorVersion` — were never set, leaving them null.

### Impact
Calling ToNonSSL() on a cloned IIOPProfile threw a NullReferenceException
Any access to configuration.ORB.GiopMinorVersion (and potentially other config-dependent fields) on a cloned instance failed at runtime

### Fix
Added a call to Configure() immediately after constructing the cloned IIOPProfile instance, ensuring the object is fully initialized before use.

### Testing
Verified configuration.ORB.GiopMinorVersion is accessible on cloned instances