### PR TITLE
Fix LocateRequest Handling

### DIFF
--- a/src/DotNetOrb.Core/GIOP/GIOPChannelHandler.cs
+++ b/src/DotNetOrb.Core/GIOP/GIOPChannelHandler.cs
@@ -245,6 +245,7 @@ namespace DotNetOrb.Core.GIOP
                         {
                             var locateRequest = (GIOPLocateRequestMessage)message;
                             locateRequest.Retain();
+
                             var inputStream = new LocateRequestInputStream(orb, locateRequest.RequestId, locateRequest.Header.GIOPVersion.Minor, locateRequest.Header.IsLittleEndian, locateRequest.Content, locateRequest.Target);
                             var codeSet = context.GetAttribute(GIOPConnection.TCSAttrKey).Get();
                             if (codeSet != null)
@@ -256,32 +257,41 @@ namespace DotNetOrb.Core.GIOP
                             {
                                 inputStream.CodeSetWChar = codeSetW;
                             }
-                            ServerRequest serverRequest = null;
+                            
                             try
                             {
-                                var requestStream = new RequestInputStream(orb, locateRequest.RequestId, locateRequest.Header.GIOPVersion.Minor, locateRequest.Header.IsLittleEndian, "_non_existent", inputStream.Buffer, true, inputStream.Target, new ServiceContext[0]);
-                                serverRequest = new ServerRequest(orb, requestStream, this);
+                                var inputObjectKey = ParsedIOR.ExtractObjectKey(inputStream.Target, orb);
+                                var mapObjectKey = orb.MapObjectKey(inputObjectKey);
+                                var isMapped = !mapObjectKey.SequenceEqual(inputObjectKey);
 
-                                if (!serverRequest.ObjectKey.SequenceEqual(ParsedIOR.ExtractObjectKey(inputStream.Target, orb)))
+                                if (isMapped)
                                 {
-                                    CORBA.Object fwd = orb.GetReference(orb.GetRootPOA(), serverRequest.ObjectKey, null, true);
+                                    CORBA.Object fwd = orb.GetReference(orb.GetRootPOA(), mapObjectKey, null, true);
 
                                     if (logger.IsDebugEnabled)
-                                    {
-                                        logger.Debug("Sending locate reply with object forward to " + orb.ObjectToString(fwd));
-                                    }
+                                        logger.Debug("Sending locate reply with 'object forward' to " + orb.ObjectToString(fwd));
 
                                     var lrOut = new LocateReplyOutputStream(orb, inputStream.RequestId, LocateStatusType12.OBJECT_FORWARD, inputStream.GiopMinor);
-
                                     lrOut.WriteObject(fwd);
 
-                                    context.WriteAndFlushAsync(lrOut).ContinueWith(x =>
+                                    SendLocateReplyAsync(lrOut).ContinueWith(x =>
                                     {
                                         fwd._Release();
                                     });
-                                    return;
                                 }
-                                DeliverRequest(serverRequest);
+                                else
+                                {
+                                    CORBA.Object here = orb.GetReference(orb.GetRootPOA(), inputObjectKey, null, true);
+
+                                    if (logger.IsDebugEnabled)
+                                        logger.Debug("Sending locate reply with 'object here'");
+
+                                    var lrOut = new LocateReplyOutputStream(orb, inputStream.RequestId, LocateStatusType12.OBJECT_HERE, inputStream.GiopMinor);
+                                    SendLocateReplyAsync(lrOut).ContinueWith(x =>
+                                    {
+                                        here._Release();
+                                    });
+                                }
                             }
                             catch (POAInternalException pie)
                             {
@@ -289,7 +299,7 @@ namespace DotNetOrb.Core.GIOP
                                     logger.Warn("Received a request with a non DotNetOrb object key");
 
                                 var lrOut = new LocateReplyOutputStream(orb, inputStream.RequestId, LocateStatusType12.UNKNOWN_OBJECT, inputStream.GiopMinor);
-                                context.WriteAndFlushAsync(lrOut);
+                                SendLocateReplyAsync(lrOut);
                             }
                         }
                         break;


### PR DESCRIPTION
### Summary
This PR fixes two bugs in the processing of GIOP `LocateRequest` messages.

---

### Fix 1: Use `SendLocateReplyAsync` instead of writing directly to `context`
**Problem:** `LocateReply` messages were not visible in Wireshark, indicating they were never actually sent on the wire.

**Root cause:** The reply was written directly to the `context` object instead of going through the proper send path.

**Fix:** Replaced direct `context` writes with calls to the official `SendLocateReplyAsync` function, which correctly serializes and dispatches the reply through the transport layer.

> ⚠️ **Open question:** What is the architectural difference between `context` and `channel`? The distinction is not fully clear to me. If a reviewer can clarify, that would help ensure this fix is complete and correct.

---

### Fix 2: Implement `OBJECT_HERE` locate status

**Problem:** The `OBJECT_HERE` response was not implemented, causing it to never be returned in `LocateReply` messages.

**Observed symptom:** In a scenario where a client establishes a bidirectional connection and expects server-initiated callbacks, those callbacks never arrived. Investigation revealed that OmniORB sends a `LocateRequest` before the first callback, and without a proper `OBJECT_HERE` reply, the callback sequence was never initiated.

**Fix:** Implemented the `OBJECT_HERE` case in the `LocateRequest` handler so that a proper `LocateReply` is returned, unblocking the bidirectional callback flow.

---

### Testing

- Verified both fixes via Wireshark: `LocateReply` messages are now visible on the wire with the correct status.
- Bidirectional callbacks are now delivered correctly in the affected scenario.