### PR TITLE
Fix: Compile errors in framework projects

### DIFF
--- a/src/DotNetOrb.Core/IIOP/ClientIIOPConnection.cs
+++ b/src/DotNetOrb.Core/IIOP/ClientIIOPConnection.cs
@@ -13,6 +13,7 @@ using DotNetty.Transport.Channels.Sockets;
 using ETF;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;

--- a/src/DotNetOrb.Core/IIOP/ClientIIOPTrafficCaptureHandler.cs
+++ b/src/DotNetOrb.Core/IIOP/ClientIIOPTrafficCaptureHandler.cs
@@ -1,8 +1,11 @@
-﻿using DotNetty.Buffers;
+﻿using System;
+using System.IO;
+using DotNetty.Buffers;
 using DotNetty.Transport.Channels;
 using DotNetty.Transport.Channels.Sockets;
 using System.Net;
 using System.Net.Sockets;
+using System.Threading.Tasks;
 
 namespace DotNetOrb.Core.IIOP;
 

--- a/src/netframework/DotNetOrb.Core/DotNetOrb.Core.csproj
+++ b/src/netframework/DotNetOrb.Core/DotNetOrb.Core.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>DotNetOrb.Core</RootNamespace>
     <AssemblyName>DotNetOrb.Core</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
@@ -369,6 +369,9 @@
     </Compile>
     <Compile Include="..\..\DotNetOrb.Core\IIOP\ClientIIOPConnection.cs">
       <Link>IIOP\ClientIIOPConnection.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DotNetOrb.Core\IIOP\ClientIIOPTrafficCaptureHandler.cs">
+      <Link>IIOP\ClientIIOPTrafficCaptureHandler.cs</Link>
     </Compile>
     <Compile Include="..\..\DotNetOrb.Core\IIOP\CommonInteroperabilityOptions.cs">
       <Link>IIOP\CommonInteroperabilityOptions.cs</Link>

--- a/src/netframework/DotNetOrb.IdlCompiler/DotNetOrb.IdlCompiler.csproj
+++ b/src/netframework/DotNetOrb.IdlCompiler/DotNetOrb.IdlCompiler.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>DotNetOrb.IdlCompiler</RootNamespace>
     <AssemblyName>DotNetOrb.IdlCompiler</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>

--- a/src/netframework/DotNetOrb.OMG/DotNetOrb.OMG.csproj
+++ b/src/netframework/DotNetOrb.OMG/DotNetOrb.OMG.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>DotNetOrb.OMG</RootNamespace>
     <AssemblyName>DotNetOrb.OMG</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>


### PR DESCRIPTION
### Problem
Fixes compile errors that were accidentally introduced alongside the "Optional TLS traffic capture to PCAP" feature. These errors went unnoticed during that PR and need to be resolved to restore a clean build including 'framework' folder.

### Root Cause
Certain project files exist under the same name in more than one location. When changes were made for the TLS/PCAP feature, this duplication was overlooked, causing build failures in the affected files.

### Changes
Fixed compile errors caused by missing or conflicting changes in duplicate-named project files
Resolves build breakage introduced as a side effect of the "Optional TLS traffic capture to PCAP" PR