### PR TITLE
Fix: Fixes non-deterministic build order in the solution by introducing explicit project references

### DIFF
--- a/examples/ChatClient/ChatClient.csproj
+++ b/examples/ChatClient/ChatClient.csproj
@@ -7,16 +7,20 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <Exec Command="$(SolutionDir)\src\idlcompiler\DotNetOrb.IdlCompiler\bin\Debug\net8.0\DotNetOrb.IdlCompiler.exe -o $(ProjectDir)compiled_idls $(ProjectDir)chat.idl" />
-  </Target>
-
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="9.0.6" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetOrb.Core\DotNetOrb.Core.csproj" />
+    <ProjectReference Include="..\..\src\idlcompiler\DotNetOrb.IdlCompiler\DotNetOrb.IdlCompiler.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+    </ProjectReference>
   </ItemGroup>
+
+  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+    <Exec Command="$(SolutionDir)\src\idlcompiler\DotNetOrb.IdlCompiler\bin\$(Configuration)\$(TargetFramework)\DotNetOrb.IdlCompiler.exe -o $(ProjectDir)compiled_idls $(ProjectDir)chat.idl" />
+  </Target>
 
 </Project>

--- a/examples/ChatServer/ChatServer.csproj
+++ b/examples/ChatServer/ChatServer.csproj
@@ -7,17 +7,20 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <Exec Command="$(SolutionDir)\src\idlcompiler\DotNetOrb.IdlCompiler\bin\Debug\net8.0\DotNetOrb.IdlCompiler.exe -o $(ProjectDir)compiled_idls $(ProjectDir)chat.idl" />
-  </Target>
-
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="9.0.6" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetOrb.Core\DotNetOrb.Core.csproj" />
-    <ProjectReference Include="..\..\src\idlcompiler\DotNetOrb.IdlCompiler\DotNetOrb.IdlCompiler.csproj" />
+    <ProjectReference Include="..\..\src\idlcompiler\DotNetOrb.IdlCompiler\DotNetOrb.IdlCompiler.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+    </ProjectReference>
   </ItemGroup>
+
+  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+    <Exec Command="$(SolutionDir)\src\idlcompiler\DotNetOrb.IdlCompiler\bin\$(Configuration)\$(TargetFramework)\DotNetOrb.IdlCompiler.exe -o $(ProjectDir)compiled_idls $(ProjectDir)chat.idl" />
+  </Target>
 
 </Project>

--- a/src/idlcompiler/DotNetOrb.IdlCompiler/DotNetOrb.IdlCompiler.csproj
+++ b/src/idlcompiler/DotNetOrb.IdlCompiler/DotNetOrb.IdlCompiler.csproj
@@ -48,4 +48,11 @@
     <PackageReference Include="System.Text.Json" Version="9.0.6" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\IDL.Grammar\IDL.Grammar.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+    </ProjectReference>
+  </ItemGroup>
+
 </Project>

--- a/src/netframework/DotNetOrb.IdlCompiler/DotNetOrb.IdlCompiler.csproj
+++ b/src/netframework/DotNetOrb.IdlCompiler/DotNetOrb.IdlCompiler.csproj
@@ -77,6 +77,12 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\idlcompiler\IDL.Grammar\IDL.Grammar.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="..\..\idlcompiler\DotNetOrb.IdlCompiler\CodeGenerator.cs">
       <Link>CodeGenerator.cs</Link>
     </Compile>

--- a/test/DotNetOrb.Test/DotNetOrb.Test.csproj
+++ b/test/DotNetOrb.Test/DotNetOrb.Test.csproj
@@ -19,10 +19,14 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetOrb.Core\DotNetOrb.Core.csproj" />
+    <ProjectReference Include="..\..\src\idlcompiler\DotNetOrb.IdlCompiler\DotNetOrb.IdlCompiler.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+    </ProjectReference>
   </ItemGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <Exec Command="$(SolutionDir)\src\idlcompiler\DotNetOrb.IdlCompiler\bin\Debug\net8.0\DotNetOrb.IdlCompiler.exe -i $(ProjectDir)idls -o $(ProjectDir)compiled_idls $(ProjectDir)idls\*.idl" />
+    <Exec Command="$(SolutionDir)\src\idlcompiler\DotNetOrb.IdlCompiler\bin\$(Configuration)\$(TargetFramework)\DotNetOrb.IdlCompiler.exe -i $(ProjectDir)idls -o $(ProjectDir)compiled_idls $(ProjectDir)idls\*.idl" />
   </Target>
 
 </Project>


### PR DESCRIPTION
### Problem
The solution structure did not express the build-time dependencies between DotNetOrb.IdlCompiler.csproj and IDL.Grammar.csproj, nor between projects consuming the IdlCompiler and the compiler project itself. This made deterministic builds impossible, as MSBuild had no way to enforce the correct build order.

### Root Cause
Without these references, MSBuild cannot construct a reliable dependency graph and may build projects in an undefined order.

### Changes
- Added a <ProjectReference> from DotNetOrb.IdlCompiler.csproj to IDL.Grammar.csproj (without referencing the output assembly) to express the build dependency
- Added a <ProjectReference> to DotNetOrb.IdlCompiler.csproj in all projects that consume the IdlCompiler (without referencing the output assembly)
- Replaced hardcoded directory names in build paths with $(Configuration) and $(TargetFramework) MSBuild variables across all affected projects