### PR TITLE
Fix: Fixes false-positive dirty file detection for ANTLR4-generated `.interp` files by enforcing LF line endings in `.gitattributes`.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
 * text=auto
+*.interp text eol=lf
 
 ###############################################################################
 # Set default behavior for command prompt diff.


### PR DESCRIPTION
## Problem

After compiling, all `.interp` files generated by ANTLR4 were consistently flagged as modified by Git, even though no actual content had changed. This created noise in `git status` and made it harder to spot real changes.

## Root Cause

ANTLR4 always generates `.interp` files with LF line endings. The repository's `.gitattributes` had automatic line ending normalization enabled, which caused Git to convert those LF endings to CRLF on checkout. On the next compile, ANTLR4 would regenerate the files with LF again — making Git detect a diff that was purely a line ending change.

## Changes

- Added an explicit `.gitattributes` rule for `*.interp` files to enforce LF line endings, preventing automatic normalization from modifying them